### PR TITLE
Strict event

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,8 @@ KeyNotGeneratedError = Class.new(StandardError)
 class Event < ApplicationRecord
   belongs_to :venue
 
+  validate :validate_duration
+
   scope :upcoming, ->(now) { where("starts_at > ?", now) }
   scope :recently, -> { order(starts_at: :asc) }
 
@@ -32,5 +34,17 @@ class Event < ApplicationRecord
 
   def formatted_opening_date
     "#{self.starts_at.strftime("%Y年%m月%d日 %H:%M")}~#{self.ends_at.strftime("%H:%M")}"
+  end
+
+  private
+
+  def validate_duration
+    if duration <= 0
+      errors[:base] << "end_at must be greater than start_at"
+    end
+
+    if duration > 24.hours
+      errors[:base] << "Too long event. Everyone will be exhausted."
+    end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,8 +1,11 @@
+require 'validators/spinal_case_validator'
+
 KeyNotGeneratedError = Class.new(StandardError)
 
 class Event < ApplicationRecord
   belongs_to :venue
 
+  validates :pretty_title, presence: true, spinal_case: true
   validate :validate_duration
 
   scope :upcoming, ->(now) { where("starts_at > ?", now) }

--- a/lib/validators/spinal_case_validator.rb
+++ b/lib/validators/spinal_case_validator.rb
@@ -1,0 +1,11 @@
+require 'active_model'
+
+class SpinalCaseValidator < ActiveModel::EachValidator
+  REGEXP   = /\A[a-z0-9]+(-[a-z0-9]+)*\z/
+
+  def validate_each(record, attribute, value)
+    unless value.to_s =~ REGEXP
+      record.errors.add(attribute, 'must be spinal case like spinal-case')
+    end
+  end
+end


### PR DESCRIPTION
**時間** （≠時刻）を2つの dateime で持つと不整合が生じがちなので、ちょっとしたバリデーションを追加します。

