### PR TITLE
Redirect to correct URL if pretty title is incorrect

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,10 +7,14 @@ class EventsController < ApplicationController
   end
 
   def show
-    pretty_title = params[:slug].split("-")[0..-2].join("-")
-    key          = params[:slug].split("-").last
+    key = params[:slug].split("-").last
 
-    @event = Event.find_by!(pretty_title: pretty_title, key: key)
+    @event = Event.find_by!(key: key)
+
+    if params[:slug] != @event.slug
+      redirect_to event_path(@event.slug), status: 301 # Moved Permanently
+    end
+
     @page_title = @event.title
   end
 end


### PR DESCRIPTION
イベント詳細ページの URL のうち、`pretty_title` 部分が現在のレコードと異なる場合に、現在の `pretty_title` を含む URL にリダイレクトするようにします。

- `pretty_title` と `key` を対にして導入するモチベーション上、`pretty_title` は一致する必要がない
  - ヒューマンリーダブルな URL をつくるための `pretty_title` （意味を持っているため変更される可能性がある）
  - 変更されたときにもリンク切れなどを起こさずページを表示するための `key`
- `pretty_title` が変更されても同一のページなので 301 Moved Permanently でリダイレクト

