### PR TITLE
Show venue address and description in event page

### DIFF
--- a/app/dashboards/venue_dashboard.rb
+++ b/app/dashboards/venue_dashboard.rb
@@ -10,7 +10,7 @@ class VenueDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     name: Field::String,
-    address: Field::String,
+    address: Field::Text,
     description: Field::Text,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -1,5 +1,2 @@
 class Venue < ApplicationRecord
-  def address_with_line_break
-    address.split(/ /).join("\n")
-  end
 end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -1,2 +1,5 @@
 class Venue < ApplicationRecord
+  def address_with_line_break
+    address.split(/ /).join("\n")
+  end
 end

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -64,7 +64,7 @@
       .access_place
         %p= "場所： #{@event.venue.name}"
       .access_address
-        = simple_format @event.venue.address_with_line_break
+        = simple_format @event.venue.address
       .access_route
         %p
         = simple_format @event.venue.description

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -64,19 +64,17 @@
       .access_place
         %p= "場所： #{@event.venue.name}"
       .access_address
-        %p
-          東京都渋谷区恵比寿4-20-3
-          %br
-          恵比寿ガーデンプレイスタワー6階
+        = simple_format @event.venue.address_with_line_break
       .access_route
         %p
-          JR恵比寿駅 東口改札より徒歩8分
-          %br
-          （改札右手の動く歩道「スカイウォーク」をご利用ください）
-      .access_button
-        =link_to 'googlemapで開く', 'https://goo.gl/maps/E9cvnrgGTD82', class: 'button_googlemap', target:'_blank'
-      .access_map
-        <iframe src="https://www.google.com/maps/embed?pb=!1m16!1m12!1m3!1d3242.4106062544242!2d139.7112813155217!3d35.64225398020354!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!2m1!1z5p2x5Lqs6YO95riL6LC35Yy65oG15q-U5a-_NC0yMC0zIOaBteavlOWvv-OCrOODvOODh-ODs-ODl-ODrOOCpOOCueOCv-ODr-ODvDbpmo4!5e0!3m2!1sja!2sjp!4v1548857064435" width="100%" height="100%" frameborder="0" style="border:0" allowfullscreen></iframe>
+        = simple_format @event.venue.description
+      -# Venue don't have google_maps_url and google_maps_embed_url yet.
+        .access_button
+          - google_maps_url = 'https://goo.gl/maps/E9cvnrgGTD82'
+          =link_to 'Google Maps で開く', google_maps_url, class: 'button_googlemap', target:'_blank'
+        .access_map
+          - google_maps_embed_url = "https://www.google.com/maps/embed?pb=!1m16!1m12!1m3!1d3242.4106062544242!2d139.7112813155217!3d35.64225398020354!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!2m1!1z5p2x5Lqs6YO95riL6LC35Yy65oG15q-U5a-_NC0yMC0zIOaBteavlOWvv-OCrOODvOODh-ODs-ODl-ODrOOCpOOCueOCv-ODr-ODvDbpmo4!5e0!3m2!1sja!2sjp!4v1548857064435"
+          %iframe{ src: google_maps_embed_url, width: "100%", height: "100%", frameborder: 0, style: "border:0", allowfullscreen: true }
 
       .eventTopics_apply
         - if @event.ended?


### PR DESCRIPTION
Google Maps の URL と地図の埋め込み用 URL を DB に持っていないので、そこは一旦後回し。

この PR は master ではなく #53 に向けています。

あと、本番データの venues.description が埋まってないのでそっちの整備をする必要はある。

## こんな感じ

![image](https://user-images.githubusercontent.com/2684231/51999022-3a99e200-24fd-11e9-8acf-7ba8ebeb20a9.png)

@tomoya-tsuji @ukstudio @SpicyCoffee 🙏 
