### PR TITLE
Add description column to talks table

### DIFF
--- a/app/dashboards/talk_dashboard.rb
+++ b/app/dashboards/talk_dashboard.rb
@@ -21,6 +21,7 @@ class TalkDashboard < Administrate::BaseDashboard
     speaker_role: Field::String,
     slide_url: Field::String,
     video_url: Field::String,
+    description: Field::Text,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -56,6 +57,7 @@ class TalkDashboard < Administrate::BaseDashboard
     :speaker_role,
     :slide_url,
     :video_url,
+    :description,
     :created_at,
     :updated_at,
   ].freeze
@@ -76,6 +78,7 @@ class TalkDashboard < Administrate::BaseDashboard
     :speaker_role,
     :slide_url,
     :video_url,
+    :description,
   ].freeze
 
   # Overwrite this method to customize how talks are displayed

--- a/db/schemata/talks.schema
+++ b/db/schemata/talks.schema
@@ -9,6 +9,7 @@ create_table "talks", force: :cascade do |t|
   t.string  "speaker_role"
   t.string  "slide_url"
   t.string  "video_url"
+  t.text    "description", null: false, default: ""
 
   t.timestamps
 end


### PR DESCRIPTION
events/show.html.haml でtalkの詳細を表示する箇所があったのでカラムを追加。
今のところ他の項目と同様にproposalからコピーしてくる想定でいます。

既存のレコードがあるので一旦`default: ""`を指定しています。カラム追加後に`default`は外す想定です。