### PR TITLE
Show talks on event page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,7 @@ class EventsController < ApplicationController
   def show
     key = params[:slug].split("-").last
 
-    @event = Event.find_by!(key: key)
+    @event = Event.eager_load(:talks, :proposals, :venue).find_by!(key: key)
 
     unless params[:slug] == @event.slug
       redirect_to event_path(@event.slug), status: 301

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,8 @@ require 'validators/spinal_case_validator'
 KeyNotGeneratedError = Class.new(StandardError)
 
 class Event < ApplicationRecord
+  has_many :talks
+  has_many :proposals
   belongs_to :venue
 
   validates :pretty_title, presence: true, spinal_case: true

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -24,41 +24,37 @@
   .eventContents_wrapper
     .showEvents_container
       %h2 Main Talks
-      - if @event.ended?
-        .after_maintalks_wrapper
-          %p 間もなく資料公開予定
+      - if @event.talks.present?
+        .before_maintalks_wrapper
+          %ul
+            - @event.talks.each do |talk|
+              %li
+                .mainSpeaker_title
+                  %p= talk.title
+                .mainSpeaker_bio
+                  %p
+                    = talk.speaker_belongs
+                    = talk.speaker_role
+                .mainSpeaker_name
+                  - if talk.speaker_sns_id.present? && talk.speaker_sns_url.present?
+                    %p
+                      = talk.speaker_name
+                      = link_to "(#{talk.speaker_sns_id})", talk.speaker_sns_url, style: "color: #fff"
+                .mainSpeaker_desc
+                  %p= simple_format(talk.description)
       - else
-        .comingsoon_maintalks_wrapper
-          %p Coming Soon...
-      -# .before_maintalks_wrapper
-      -#   %ul
-      -#     %li
-      -#       .mainSpeaker_title
-      -#         %p 共創ワークショップを実践してわかった仮説の立て方
-      -#       .mainSpeaker_bio
-      -#         %p 株式会社マネーフォワード　Money Forward X本部 UXデザイナー
-      -#       .mainSpeaker_name
-      -#         %p 佐々木 俊弥(@toshiyassk)
-      -#       .mainSpeaker_desc
-      -#         %p クライアントとの共創によってユーザー中心のサービスを開発するための基本となるメソッド（Money Forward Service Design）を使いながら、ワークショップを実践してきた経験からわかった仮説の立て方について発表します。
-      -#     %li
-      -#       .mainSpeaker_title
-      -#         %p ユーザーを中心にした仮説のつくりかた
-      -#       .mainSpeaker_bio
-      -#         %p 株式会社alma　プロダクトマネージャー/エンジニア
-      -#       .mainSpeaker_name
-      -#         %p 加藤 健路(@slum_danker)
-      -#       .mainSpeaker_desc
-      -#         %p プロダクトのアイデアを出し、リリースするまでの流れにおいて、どのように仮説を立てるとよかったのか、自分でサービスを複数つくった事例（Cocoda!や週末でつくっているプロダクト）を交えながら、アンチパターンやグッドパターンを赤裸々に話していきたいと思ってます
-      -#     %li
-      -#       .mainSpeaker_title
-      -#         %p WEBサービス開発における仮説思考のための道具
-      -#       .mainSpeaker_bio
-      -#         %p ユアマイスター株式会社  CTO
-      -#       .mainSpeaker_name
-      -#         %p 星 永亮(@inase17000)
-      -#       .mainSpeaker_desc
-      -#         %p 書籍「仮説思考」から得た考え方の紹介、案件の起案時にエンジニアとディレクターが心がけていること、仮説を立てる時に煮詰まったら、こんな風に考えてみては？
+        - if @event.ended?
+          .after_maintalks_wrapper
+            -# 現状LT大会のみここに入る
+            %p 間もなく資料公開予定
+        - else
+          - if @event.proposals.present?
+            -# proposalがあったらここ
+            .comingsoon_maintalks_wrapper
+              %p Coming Soon...
+          - else
+            .comingsoon_maintalks_wrapper
+              %p Coming Soon...
 
       %h2 Access
       .access_place


### PR DESCRIPTION
とりいそぎデータを入力したので出してみました。リンクの文字色がデフォルトで見づらかったので、一旦白にしています。あと分岐も整理してみて、多分これで事足りるはず(自信60%)

## talkがあってdescriptionも入力されてる

![image](https://user-images.githubusercontent.com/23812/52120470-c297fd00-265f-11e9-930e-a875cb457d74.png)

## talkはあるけどdescriptionが空

仮説検証〜ピボットはdescが未入力です。

![image](https://user-images.githubusercontent.com/23812/52120495-d0e61900-265f-11e9-9a42-792ceb06af37.png)

## talkがない

現状はLT大会のみで、LTのデータの持ち方をちょっと考える必要があるのと数が多いのでがんばりがいる(メイントークと違ってproposalもないので目視&手入力になりそう)

![image](https://user-images.githubusercontent.com/23812/52120503-d9d6ea80-265f-11e9-9049-833e1b4678cf.png)
