### PR TITLE
Edit talk

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
+  private
+
+  def render_404(err = nil)
+    render 'errors/404', status: 404
+  end
 end

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class TalksController < ApplicationController
+  def edit
+    @talk = Talk.find_by!(id: params[:id], secret_token: params[:secret_token])
+  end
+
+  def update
+    @talk = Talk.find_by!(id: params[:id], secret_token: params[:secret_token])
+
+    if @talk.update(editable_params)
+      redirect_to edit_event_talk_path(event_slug: @talk.event.slug, id: @talk.id, secret_token: @talk.secret_token)
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def editable_params
+    params.require(:talk).permit(
+      # Speaker info
+      :speaker_name,
+      :speaker_email,
+      :speaker_sns_id,
+      :speaker_sns_url,
+      :speaker_belongs,
+      :speaker_role,
+      # Talk info
+      :title,
+      :description,
+      # Materials
+      :slide_url,
+      :video_url,
+    )
+  end
+end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -16,7 +16,7 @@ class Talk < ApplicationRecord
   # @return [String, nil]
   def secret_edit_path
     return nil if new_record?
-    Rails.application.routes.url_helpers.edit_database_talk_path(self, secret_token: secret_token)
+    Rails.application.routes.url_helpers.edit_event_talk_path(event_slug: event.slug, id: id, secret_token: secret_token)
   end
 
   private

--- a/app/views/errors/404.html.haml
+++ b/app/views/errors/404.html.haml
@@ -1,0 +1,1 @@
+404 Not Found

--- a/app/views/talks/edit.html.haml
+++ b/app/views/talks/edit.html.haml
@@ -1,0 +1,44 @@
+%div{ style: 'padding-top: 100px; width: 800px; margin: 0 auto;' }
+  - if @talk.errors.any?
+    %ul
+      - @talk.errors.full_messages.each do |message|
+        %li{ style: 'color: red;' }= message
+
+  = form_for @talk, url: event_talk_path(event_slug: @talk.event.slug, id: @talk.id, secret_token: @talk.secret_token) do |f|
+    %h4 Speaker Info
+
+    = f.label :speaker_name
+    = f.text_field :speaker_name, class: 'form-control'
+
+    = f.label :speaker_email
+    = f.text_field :speaker_email
+
+    = f.label :speaker_sns_id
+    = f.text_field :speaker_sns_id
+
+    = f.label :speaker_sns_url
+    = f.text_field :speaker_sns_url
+
+    = f.label :speaker_belongs
+    = f.text_field :speaker_belongs
+
+    = f.label :speaker_role
+    = f.text_field :speaker_role
+
+    %h4 Talk Info
+
+    = f.label :title
+    = f.text_field :title
+
+    = f.label :description
+    = f.text_area :description
+
+    %h4 Materials
+
+    = f.label :slide_url
+    = f.text_field :slide_url
+
+    = f.label :video_url
+    = f.text_field :video_url
+
+    = f.submit 'Submit'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   root to: "top#index"
 
-  resources :events, param: :slug, only: %i[index show]
+  resources :events, param: :slug, only: %i[index show] do
+    resources :talks, only: %i[edit update]
+  end
 
   get "/sitemap", to: "sitemaps#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
   root to: "top#index"
 
-  get "/events", to: "events#index"
-  get "/events/:slug", to: "events#show", as: "event"
+  resources :events, param: :slug, only: %i[index show]
 
   get "/sitemap", to: "sitemaps#index"
 

--- a/spec/factories/talks.rb
+++ b/spec/factories/talks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :talk do
+    event
+
+    sequence(:title) {|i| "talk_title_#{i}" }
+    sequence(:speaker_name) {|i| "speaker_name_#{i}" }
+    sequence(:speaker_email) {|i| "#{i}@example.com" }
+    sequence(:description) {|i| "talk_desc_#{i}" }
+    secret_token { SecureRandom.alphanumeric(32) }
+  end
+end

--- a/spec/requests/talks_spec.rb
+++ b/spec/requests/talks_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe 'Talks page', type: :request do
+  describe 'edit' do
+    let(:talk) { create(:talk) }
+
+    context 'with secret_token' do
+      it 'should be accessible' do
+        get "/events/#{talk.event.slug}/talks/#{talk.id}/edit?secret_token=#{talk.secret_token}"
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'without secret_token' do
+      it 'should not be found' do
+        get "/events/#{talk.event.slug}/talks/#{talk.id}/edit"
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#87 のつづき。

- 編集ページつくった
  - 細かいところはともかく、とりあえずガッと
- `secret_token` が一致しないと 404 を返す

## 懸念事項

- スタイルが当たってない
  - cc/ @tomoya-tsuji 
- URL に `secret_token` を含んでいるので外部サイトへのリンクに `rel=noreferrer` つけたい
  - このページにある外部サイトへのリンクは上部メニューにある Twitter リンクだけだが、layout で定義されてるのでいじりにくい

## Screehsnot

![image](https://user-images.githubusercontent.com/2684231/52539292-bdedea00-2dbf-11e9-8467-911943caf462.png)
