### PR TITLE
Add published column to Event

### DIFF
--- a/db/schemata/events.schema
+++ b/db/schemata/events.schema
@@ -6,6 +6,7 @@ create_table "events", force: :cascade do |t|
   t.integer  "venue_id",     null:   false
   t.datetime "starts_at",    null:   false
   t.datetime "ends_at",      null:   false
+  t.boolean  "published",    null:   false, default: false
   t.index    "pretty_title", unique: true
   t.index    "key",          unique: true
 


### PR DESCRIPTION
```
[WARNING] PostgreSQL doesn't support adding a new column except for the last position. events.published will be added to the last.
add_column("events", "published", :boolean, {:null=>false, :default=>false})

# ALTER TABLE "events" ADD "published" boolean DEFAULT FALSE NOT NULL
```

Eventを登録すると即時公開されてしまい、connpassの方とタイミングを合わせるのが面倒。なので公開・非公開を判定するためのBooleanカラムを追加して、コントロールできるようにします。このPRではカラムの追加のみ。

Booleanではなく、公開日時を入力するようにしようかとも思ったけど、運用としては公開する日時を入れるよりconnpassの公開とあわせてサクッと手で切り替えできる方がよさそうと思ったのでBooleanにしました。
