### PR TITLE
Add connpass_url to Event

### DIFF
--- a/db/schemata/events.schema
+++ b/db/schemata/events.schema
@@ -6,6 +6,7 @@ create_table "events", force: :cascade do |t|
   t.integer  "venue_id",     null:   false
   t.datetime "starts_at",    null:   false
   t.datetime "ends_at",      null:   false
+  t.string   "connpass_url", null:   false, default: "" # TODO: 過去のイベントのURLをうめたらdefaultは外したい
   t.boolean  "published",    null:   false, default: false
   t.index    "pretty_title", unique: true
   t.index    "key",          unique: true


### PR DESCRIPTION
```
ridgepole -c config/database.yml --apply -f db/schemata/Schemafile -E development
Apply `db/schemata/Schemafile`
[WARNING] PostgreSQL doesn't support adding a new column except for the last position. events.connpass_url will be added to the last.
-- add_column("events", "connpass_url", :string, {:null=>false, :default=>""})
   -> 0.0506s
```

人類は気づいてしまった… connpass urlを保存するカラムがないことに…

- connpassのURLとIDどっちを保存するか迷った
    - コピペが簡単
    - URLの形式が変わらない保証がない
    - という理由でURLを保存することにした
- カラム名をconnpass_urlとentry_urlみたいな抽象度の高い方にするか迷った
    - 当分connpassしか使わないだろうからconnpass_urlでいいかってなった