### PR TITLE
bundle update nokogiri because of CVE-2019-5477

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       railties (>= 3.1)
     multi_json (1.13.1)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
     pry (0.12.2)


### PR DESCRIPTION
<img width="774" alt="image" src="https://user-images.githubusercontent.com/2684231/63501616-e725ca80-c506-11e9-920c-cfb2c96719f2.png">
